### PR TITLE
refactor: fix release workflow

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,13 +18,11 @@ builds:
             goarch: arm64
 
 archives:
-    - formats:
-          - tar.gz
-      name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }"
+    - format: "tar.gz"
+      name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
       format_overrides:
           - goos: windows
-            formats:
-                - zip
+            format: "zip"
 
 checksum:
     name_template: "{{ .ProjectName }}_v{{ .Version }}_checksums.txt"


### PR DESCRIPTION
use deprecated fields since hook is using an older version of goreleaser